### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-	"name":         "grunt-assetpush",
-	"version":      "0.2.0",
-	"description":  "Grunt task for appending HTML tags for JS/CSS files",
+	"name": "grunt-assetpush",
+	"version": "0.2.0",
+	"description": "Grunt task for appending HTML tags for JS/CSS files",
 	"author": {
 		"name": "Gustavo Henke",
-		"url":  "https://github.com/gustavohenke"
+		"url": "https://github.com/gustavohenke"
 	},
 	"repository": {
 		"type": "git",
-		"url":  "git://github.com/gustavohenke/grunt-assetpush.git"
+		"url": "git://github.com/gustavohenke/grunt-assetpush.git"
 	},
 	"bugs": {
 		"url": "https://github.com/gustavohenke/grunt-assetpush/issues"
@@ -24,12 +24,12 @@
 		"test": "grunt test"
 	},
 	"devDependencies": {
-		"grunt-contrib-jshint":     "~0.6.4",
-		"grunt-contrib-nodeunit":   "~0.2.1",
-		"grunt-contrib-clean":      "~0.5.0",
-		"grunt-jscs-checker":       "~0.2.0"
+		"grunt-contrib-jshint": "~0.6.4",
+		"grunt-contrib-nodeunit": "~0.2.1",
+		"grunt-contrib-clean": "~0.5.0",
+		"grunt-jscs-checker": "~0.2.0"
 	},
 	"peerDependencies": {
-		"grunt": "~0.4.0"
+		"grunt": ">=0.4.0"
 	}
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
